### PR TITLE
[ci skip] Get more Open Source Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LinkedIn AutoConnect - Chrome Extension
+# LinkedIn AutoConnect - Chrome Extension [![Help Contribute to Open Source](https://www.codetriage.com/felladrin/linkedin-autoconnect-chrome-extension/badges/users.svg)](https://www.codetriage.com/felladrin/linkedin-autoconnect-chrome-extension)
 
 This extensions is for every LinkedIn user who is tired of manually clicking to 'Connect' all those recruiters from their dream company. Or those who are willing to add everyone from their college course.
 


### PR DESCRIPTION
[CodeTriage](https://www.codetriage.com/) is an app I have maintained
for the past 4-5 years with the goal of getting people involved in
Open Source projects like this one. The app sends subscribers a random
open issue for them to help "triage". For some languages you can also
suggested areas to add documentation.

The initial approach was inspired by seeing the work of the small
core team spending countless hours asking "what version was
this in" and "can you give us an example app". The idea is to
outsource these small interactions to a huge team of volunteers
and let the core team focus on their work.

I want to add a badge to the README of this project. The idea is to
provide an easy link for people to get started contributing to this
project. A badge indicates the number of people currently subscribed
to help the repo. The color is based off of open issues in the project.

Here are some examples of other projects that have a badge in their
README:

- https://github.com/crystal-lang/crystal
- https://github.com/rails/rails
- https://github.com/codetriage/codetriage

Thanks for building open source software, I would love to help you find some helpers.